### PR TITLE
Fix: Use Secrets instead of Variables

### DIFF
--- a/.github/workflows/auto-merge-deploy.yml
+++ b/.github/workflows/auto-merge-deploy.yml
@@ -1,18 +1,18 @@
 name: Auto-merge & Deploy
 
-# Triggers on push to any claude/* branch EXCEPT the deploy target itself
+# Triggers on push to any claude/* branch — merges into main and deploys
 on:
   push:
     branches:
       - 'claude/**'
-      - '!claude/tradovate-api-research-DPnl9'
     paths-ignore:
       - 'docs/**'
       - '*.md'
       - 'server_status.json'
+      - 'system_status.json'
 
 env:
-  DEPLOY_BRANCH: claude/tradovate-api-research-DPnl9
+  DEPLOY_BRANCH: main
   BOT_DIR: /root/tradovate-bot
   SERVICE_NAME: tradovate-bot
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI — Tests & Lint
 
 on:
   push:
-    branches: [main, master, claude/tradovate-api-research-DPnl9]
+    branches: [main, master, 'claude/**']
   pull_request:
-    branches: [main, master, claude/tradovate-api-research-DPnl9]
+    branches: [main, master]
 
 jobs:
   test:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,18 +3,19 @@ name: Deploy to Server
 # Fires on push to main/master or the deploy branch.
 on:
   push:
-    branches: [main, master, claude/tradovate-api-research-DPnl9]
+    branches: [main, master]
     paths-ignore:
       - 'docs/**'
       - '*.md'
       - '.github/workflows/deploy-pages.yml'
       - 'server_status.json'
+      - 'system_status.json'
   workflow_dispatch:
 
 env:
   BOT_DIR: /root/tradovate-bot
   SERVICE_NAME: tradovate-bot
-  DEPLOY_BRANCH: claude/tradovate-api-research-DPnl9
+  DEPLOY_BRANCH: main
 
 jobs:
   # ── Step 1: Quick syntax check before deploying ──

--- a/setup_vps.sh
+++ b/setup_vps.sh
@@ -30,7 +30,7 @@ err()  { echo -e "${RED}[x]${NC} $1"; exit 1; }
 # ── Config ──────────────────────────────────────────────────
 BOT_DIR="/root/tradovate-bot"
 REPO_URL="https://github.com/motitap-dotcom/Tradovate-Bot.git"
-BRANCH="claude/tradovate-api-research-DPnl9"
+BRANCH="main"
 SERVICE_NAME="tradovate-bot"
 
 echo -e "${CYAN}"


### PR DESCRIPTION
All workflows and setup_vps.sh were hardcoded to use claude/tradovate-api-research-DPnl9 as the deploy branch. Updated to use main — matching the actual deploy flow described in CLAUDE.md. CI now triggers on all claude/* branches.

https://claude.ai/code/session_01RE1oP48CiM1CwCLBtPcJ3C