### PR TITLE
Add early contract rollover based on expiration dates

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -225,31 +225,123 @@ class TradovateBot:
     # Contract rollover
     # ─────────────────────────────────────────
 
+    @staticmethod
+    def _next_liquid_contract(base_symbol: str, current_contract: str) -> str | None:
+        """
+        Compute the next liquid contract name based on the rollover schedule.
+        E.g. for GC with current GCH6 (Mar 2026, non-liquid for gold),
+        returns GCJ6 (Apr 2026, the next liquid month).
+
+        Contract name format: <BASE><MONTH_CODE><YEAR_DIGIT>
+        e.g. NQH6 = NQ + H(Mar) + 6(2026), GCJ6 = GC + J(Apr) + 6(2026)
+        """
+        liquid_months = config.CONTRACT_LIQUID_MONTHS.get(base_symbol)
+        if not liquid_months:
+            return None
+
+        # Parse current contract: last char = year digit, second-to-last = month code
+        if len(current_contract) < len(base_symbol) + 2:
+            return None
+
+        suffix = current_contract[len(base_symbol):]  # e.g. "H6"
+        month_code = suffix[0]
+        year_digit = int(suffix[1])
+
+        current_month_num = config.MONTH_CODES.get(month_code)
+        if current_month_num is None:
+            return None
+
+        # Current year (2-digit sense: 6 = 2026)
+        current_year = year_digit
+
+        # Find the next liquid month AFTER the current one
+        # First, try remaining months in the same year
+        for mc in liquid_months:
+            mn = config.MONTH_CODES[mc]
+            if mn > current_month_num:
+                return f"{base_symbol}{mc}{current_year}"
+
+        # Wrap to next year, take first liquid month
+        next_year = (current_year + 1) % 10
+        return f"{base_symbol}{liquid_months[0]}{next_year}"
+
     def _check_contract_rollover(self):
         """
         Check if any active contracts need to roll to the next front-month.
-        Called periodically (e.g. once per main-loop cycle).
-        Detects when Tradovate's suggest_contract returns a different symbol
-        than what we're currently trading, and switches over.
+
+        Two-phase approach:
+        1. DATE-BASED (proactive): If the current contract expires within
+           ROLLOVER_DAYS_BEFORE_EXPIRY days, compute the next liquid contract
+           from the schedule and switch immediately.
+        2. SUGGEST-BASED (fallback): If Tradovate's suggest API returns a
+           different contract, follow it.
+
+        This ensures we roll early enough to avoid low-liquidity contracts
+        near expiration, even when the suggest API hasn't updated yet.
         """
         if self.dry_run:
             return
 
+        today = now_et().date()
+
         for symbol in list(self.contract_map.keys()):
             old_contract = self.contract_map[symbol]
+            new_contract = None
+            new_contract_data = None
+            rollover_reason = ""
 
-            new = self.api.suggest_contract(symbol)
-            if not new:
+            # ── Phase 1: Date-based early rollover ──
+            try:
+                maturity = self.api.get_contract_maturity(old_contract)
+                if maturity:
+                    from datetime import date as date_type
+                    if isinstance(maturity, str):
+                        expiry_date = date_type.fromisoformat(maturity)
+                    else:
+                        expiry_date = maturity
+
+                    days_to_expiry = (expiry_date - today).days
+
+                    if days_to_expiry <= config.ROLLOVER_DAYS_BEFORE_EXPIRY:
+                        next_name = self._next_liquid_contract(symbol, old_contract)
+                        if next_name and next_name != old_contract:
+                            # Verify the next contract exists on Tradovate
+                            verified = self.api.find_contract(next_name)
+                            if verified:
+                                new_contract = next_name
+                                new_contract_data = verified
+                                rollover_reason = (
+                                    f"expiry-based: {old_contract} expires {maturity} "
+                                    f"({days_to_expiry}d away, threshold={config.ROLLOVER_DAYS_BEFORE_EXPIRY}d)"
+                                )
+                            else:
+                                logger.warning(
+                                    "Early rollover: computed %s but contract not found on Tradovate",
+                                    next_name,
+                                )
+            except Exception as e:
+                logger.warning("Date-based rollover check failed for %s: %s", symbol, e)
+
+            # ── Phase 2: Suggest API fallback ──
+            if not new_contract:
+                try:
+                    suggested = self.api.suggest_contract(symbol)
+                    if suggested:
+                        suggested_name = suggested.get("name", "")
+                        if suggested_name and suggested_name != old_contract:
+                            new_contract = suggested_name
+                            new_contract_data = suggested
+                            rollover_reason = f"suggest-api: Tradovate returned {suggested_name}"
+                except Exception as e:
+                    logger.warning("Suggest-based rollover check failed for %s: %s", symbol, e)
+
+            if not new_contract:
                 continue
 
-            new_contract = new.get("name", "")
-            if new_contract == old_contract:
-                continue
-
-            # Front-month changed — rollover needed
+            # ── Execute rollover ──
             logger.warning(
-                "CONTRACT ROLLOVER: %s changed from %s -> %s",
-                symbol, old_contract, new_contract,
+                "CONTRACT ROLLOVER: %s from %s -> %s (%s)",
+                symbol, old_contract, new_contract, rollover_reason,
             )
 
             # Unsubscribe old contract from market data
@@ -278,7 +370,7 @@ class TradovateBot:
 
             logger.info(
                 "Rollover complete: %s now trading %s (id=%s)",
-                symbol, new_contract, new.get("id"),
+                symbol, new_contract, new_contract_data.get("id") if new_contract_data else "?",
             )
 
     # ─────────────────────────────────────────

--- a/config.py
+++ b/config.py
@@ -265,6 +265,42 @@ CONTRACT_SPECS = {
 }
 
 # ─────────────────────────────────────────────
+# Contract Rollover Schedule
+# ─────────────────────────────────────────────
+# How many calendar days before expiration to roll to the next contract.
+# Tradovate's suggest API often lags, so we roll proactively.
+ROLLOVER_DAYS_BEFORE_EXPIRY = 8
+
+# Liquid contract months per product family.
+# CME futures use month codes: F=Jan, G=Feb, H=Mar, J=Apr, K=May, M=Jun,
+#                               N=Jul, Q=Aug, U=Sep, V=Oct, X=Nov, Z=Dec
+# Only months listed here are considered for rollover.
+CONTRACT_LIQUID_MONTHS = {
+    # Equity indices: quarterly (H=Mar, M=Jun, U=Sep, Z=Dec)
+    "NQ": ["H", "M", "U", "Z"],
+    "ES": ["H", "M", "U", "Z"],
+    "MNQ": ["H", "M", "U", "Z"],
+    "MES": ["H", "M", "U", "Z"],
+    # Gold: even months (G=Feb, J=Apr, M=Jun, Q=Aug, V=Oct, Z=Dec)
+    "GC": ["G", "J", "M", "Q", "V", "Z"],
+    "MGC": ["G", "J", "M", "Q", "V", "Z"],
+    # Crude Oil: every month
+    "CL": ["F", "G", "H", "J", "K", "M", "N", "Q", "U", "V", "X", "Z"],
+    "MCL": ["F", "G", "H", "J", "K", "M", "N", "Q", "U", "V", "X", "Z"],
+    # Silver: quarterly-ish (H=Mar, K=May, N=Jul, U=Sep, Z=Dec)
+    "SI": ["H", "K", "N", "U", "Z"],
+    # Natural Gas: every month
+    "NG": ["F", "G", "H", "J", "K", "M", "N", "Q", "U", "V", "X", "Z"],
+}
+
+# Month code → month number mapping
+MONTH_CODES = {
+    "F": 1, "G": 2, "H": 3, "J": 4, "K": 5, "M": 6,
+    "N": 7, "Q": 8, "U": 9, "V": 10, "X": 11, "Z": 12,
+}
+MONTH_CODE_REVERSE = {v: k for k, v in MONTH_CODES.items()}
+
+# ─────────────────────────────────────────────
 # Trading Session Times (Eastern Time)
 # ─────────────────────────────────────────────
 # US equity open for ORB calculation

--- a/test_all.py
+++ b/test_all.py
@@ -1064,6 +1064,120 @@ test_e2e_risk_cap()
 
 
 # ─────────────────────────────────────────────
+# Contract Rollover Tests
+# ─────────────────────────────────────────────
+
+print("\n--- Contract Rollover ---")
+
+
+@test("_next_liquid_contract: NQ H6 -> M6 (quarterly)")
+def test_rollover_nq_h_to_m():
+    from bot import TradovateBot
+    result = TradovateBot._next_liquid_contract("NQ", "NQH6")
+    assert result == "NQM6", f"Expected NQM6, got {result}"
+
+
+@test("_next_liquid_contract: NQ Z5 -> H6 (year wrap)")
+def test_rollover_nq_year_wrap():
+    from bot import TradovateBot
+    result = TradovateBot._next_liquid_contract("NQ", "NQZ5")
+    assert result == "NQH6", f"Expected NQH6, got {result}"
+
+
+@test("_next_liquid_contract: GC H6 -> J6 (gold skips odd months)")
+def test_rollover_gc_h_to_j():
+    from bot import TradovateBot
+    result = TradovateBot._next_liquid_contract("GC", "GCH6")
+    assert result == "GCJ6", f"Expected GCJ6, got {result}"
+
+
+@test("_next_liquid_contract: GC Z5 -> G6 (gold year wrap to Feb)")
+def test_rollover_gc_year_wrap():
+    from bot import TradovateBot
+    result = TradovateBot._next_liquid_contract("GC", "GCZ5")
+    assert result == "GCG6", f"Expected GCG6, got {result}"
+
+
+@test("_next_liquid_contract: CL F6 -> G6 (crude every month)")
+def test_rollover_cl_monthly():
+    from bot import TradovateBot
+    result = TradovateBot._next_liquid_contract("CL", "CLF6")
+    assert result == "CLG6", f"Expected CLG6, got {result}"
+
+
+@test("_next_liquid_contract: ES U6 -> Z6 (ES quarterly)")
+def test_rollover_es_u_to_z():
+    from bot import TradovateBot
+    result = TradovateBot._next_liquid_contract("ES", "ESU6")
+    assert result == "ESZ6", f"Expected ESZ6, got {result}"
+
+
+@test("_next_liquid_contract: unknown symbol returns None")
+def test_rollover_unknown():
+    from bot import TradovateBot
+    result = TradovateBot._next_liquid_contract("FAKE", "FAKEH6")
+    assert result is None
+
+
+@test("Date-based rollover triggers when contract expires within threshold")
+def test_date_based_rollover():
+    from bot import TradovateBot
+    from unittest.mock import MagicMock, patch
+    from datetime import date, timedelta
+
+    bot = TradovateBot(dry_run=False)
+    bot.api = MagicMock()
+    bot.md_stream = None
+    bot.contract_map = {"NQ": "NQH6"}
+
+    # Contract expires in 5 days (within 8-day threshold)
+    expiry = (date.today() + timedelta(days=5)).isoformat()
+    bot.api.get_contract_maturity.return_value = expiry
+    bot.api.find_contract.return_value = {"id": 999, "name": "NQM6"}
+    bot.api.suggest_contract.return_value = None
+
+    with patch("bot.now_et") as mock_now:
+        mock_now.return_value = datetime.now(ZoneInfo("America/New_York"))
+        bot._check_contract_rollover()
+
+    assert bot.contract_map["NQ"] == "NQM6", f"Expected NQM6, got {bot.contract_map['NQ']}"
+
+
+@test("No rollover when expiry is far away")
+def test_no_rollover_far_expiry():
+    from bot import TradovateBot
+    from unittest.mock import MagicMock, patch
+    from datetime import date, timedelta
+
+    bot = TradovateBot(dry_run=False)
+    bot.api = MagicMock()
+    bot.md_stream = None
+    bot.contract_map = {"NQ": "NQH6"}
+
+    # Contract expires in 20 days (outside 8-day threshold)
+    expiry = (date.today() + timedelta(days=20)).isoformat()
+    bot.api.get_contract_maturity.return_value = expiry
+    bot.api.suggest_contract.return_value = None
+
+    with patch("bot.now_et") as mock_now:
+        mock_now.return_value = datetime.now(ZoneInfo("America/New_York"))
+        bot._check_contract_rollover()
+
+    assert bot.contract_map["NQ"] == "NQH6", "Should NOT have rolled over"
+
+
+test_rollover_nq_h_to_m()
+test_rollover_nq_year_wrap()
+test_rollover_gc_h_to_j()
+test_rollover_gc_year_wrap()
+test_rollover_cl_monthly()
+test_rollover_es_u_to_z()
+test_rollover_unknown()
+test_date_based_rollover()
+test_no_rollover_far_expiry()
+
+
+# ─────────────────────────────────────────────
 # FINAL SUMMARY
 # ─────────────────────────────────────────────
 


### PR DESCRIPTION
Instead of relying solely on Tradovate's suggest API (which often lags),
the bot now proactively rolls contracts when they're within 8 days of
expiration. Uses a per-product liquid months schedule (e.g., gold trades
even months only, indices are quarterly) to compute the next contract.

The suggest API remains as a fallback for cases not covered by the schedule.

https://claude.ai/code/session_01TLc8J913KU7YqVZWL9W9R9