### PR TITLE
Use netLiq as primary balance metric to match FundedNext dashboard

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -179,10 +179,18 @@ class TradovateBot:
         try:
             snapshot = self.api.get_cash_balance()
             if snapshot and not snapshot.get("errorText"):
-                balance = snapshot.get("totalCashValue") or snapshot.get("netLiq")
+                # Use netLiq (net liquidation) as primary balance —
+                # this matches what FundedNext displays on their dashboard
+                # and includes unrealized P&L in the balance figure.
+                net_liq = snapshot.get("netLiq")
+                total_cash = snapshot.get("totalCashValue")
+                balance = net_liq or total_cash
                 if balance is not None:
                     self.risk.set_initial_balance(balance)
-                    logger.info("Initial balance from API: $%.2f", balance)
+                    logger.info(
+                        "Initial balance from API: $%.2f (netLiq=$%s, totalCash=$%s)",
+                        balance, net_liq, total_cash,
+                    )
                     return
             logger.warning("Could not fetch initial balance — using config default $%.2f",
                           config.ACTIVE_CHALLENGE["account_size"])
@@ -839,21 +847,34 @@ class TradovateBot:
                 if snapshot.get("errorText"):
                     logger.warning("Cash balance error: %s", snapshot["errorText"])
                     return
-                # CashBalanceSnapshot fields: totalCashValue, netLiq, openPnL, realizedPnL
-                balance = snapshot.get("totalCashValue") or snapshot.get("netLiq")
-                if balance is not None:
-                    # If set_initial_balance never succeeded at startup, do it now
-                    # so day_start_balance reflects the real balance, not config default
-                    if not self.risk._balance_initialized:
-                        logger.warning(
-                            "Initial balance was never set — setting now from API: $%.2f",
-                            balance,
-                        )
-                        self.risk.set_initial_balance(balance)
-                    unrealized = snapshot.get("openPnL", 0.0)
-                    self.risk.update_balance(balance, unrealized)
+                # Use netLiq as primary balance (matches FundedNext dashboard).
+                # When using netLiq, openPnL is already baked in, so pass 0
+                # for unrealized to avoid double-counting.
+                net_liq = snapshot.get("netLiq")
+                total_cash = snapshot.get("totalCashValue")
+                open_pnl = snapshot.get("openPnL", 0.0)
+
+                if net_liq is not None:
+                    balance = net_liq
+                    unrealized = 0.0  # already included in netLiq
+                elif total_cash is not None:
+                    balance = total_cash
+                    unrealized = open_pnl  # add separately
                 else:
-                    logger.debug("Cash balance snapshot has no totalCashValue/netLiq: %s", snapshot)
+                    logger.debug("Cash balance snapshot has no netLiq/totalCashValue: %s", snapshot)
+                    return
+
+                if not self.risk._balance_initialized:
+                    logger.warning(
+                        "Initial balance was never set — setting now from API: $%.2f",
+                        balance,
+                    )
+                    self.risk.set_initial_balance(balance)
+                self.risk.update_balance(balance, unrealized)
+                logger.debug(
+                    "Balance sync: netLiq=$%s totalCash=$%s openPnL=$%s",
+                    net_liq, total_cash, open_pnl,
+                )
         except Exception as e:
             logger.error("Balance sync error: %s", e)
 


### PR DESCRIPTION
## Summary
Updated balance initialization and synchronization logic to prioritize `netLiq` (net liquidation value) over `totalCashValue` as the primary balance metric. This aligns the bot's balance tracking with what FundedNext displays on their dashboard and ensures unrealized P&L is properly accounted for.

## Key Changes
- **Balance initialization** (`_init_balance_from_api`): Changed to use `netLiq` as the primary balance source, falling back to `totalCashValue` only if `netLiq` is unavailable
- **Balance synchronization** (`_sync_balance`): Refactored to intelligently handle the two balance metrics:
  - When `netLiq` is available: use it directly with `unrealized = 0.0` (since P&L is already included)
  - When only `totalCashValue` is available: use it with `openPnL` added separately to avoid double-counting
- **Enhanced logging**: Added detailed debug logging to track all three balance components (`netLiq`, `totalCashValue`, `openPnL`) for better visibility into balance calculations
- **Code clarity**: Added explanatory comments documenting why `netLiq` is preferred and how unrealized P&L is handled in each scenario

## Implementation Details
The key insight is that `netLiq` already includes unrealized P&L, so when using it as the balance, the unrealized component should be set to 0 to prevent double-counting. The fallback to `totalCashValue` + `openPnL` maintains backward compatibility if `netLiq` is unavailable from the API.

https://claude.ai/code/session_01BSCWgTN17rUdjey6vCH9p2