### PR TITLE
Add dynamic consistency-adjusted profit target calculation

### DIFF
--- a/config.py
+++ b/config.py
@@ -87,6 +87,7 @@ CHALLENGE_SETTINGS = {
         "drawdown_trails_unrealized": True,
         "organization": "",               # FundedNext uses empty string (NOT "funded-next")
         "consistency_rule_pct": 0.40,     # Max single-day profit = 40% of total profit
+        "consistency_rule": 0.40,         # Alias — used by target calculation
         "daily_profit_cap": 2_400,        # Just under current highest day ($2,426)
     },
 }

--- a/publish_dashboard.py
+++ b/publish_dashboard.py
@@ -388,19 +388,39 @@ function render() {{
       <span class="value gray">${{t.timestamp || 'N/A'}}</span></div>
   `;
 
-  // Challenge progress
+  // Challenge progress (with consistency rule)
   const profit = bal - 50000;
-  const target = 5000;
-  const pct = Math.max(0, Math.min(100, (profit / target) * 100));
+  const sum = j.summary || {{}};
+  const baseTarget = sum.base_target || 3000;
+  const effectiveTarget = sum.effective_target || baseTarget;
+  const consistencyAdj = sum.consistency_adjusted || false;
+  const highestDay = sum.highest_day_profit || 0;
+  const pct = Math.max(0, Math.min(100, (profit / effectiveTarget) * 100));
+  const remaining = Math.max(0, effectiveTarget - profit);
   const barColor = profit >= 0 ? '#3fb950' : '#f85149';
+
+  let targetNote = '';
+  if (consistencyAdj) {{
+    targetNote = `<div class="row" style="margin-top:6px">
+      <span class="label yellow">Target raised from $${{fmt(baseTarget,0)}} due to consistency rule</span></div>
+      <div class="row"><span class="label">Highest Day Profit</span>
+        <span class="value">$${{fmt(highestDay)}}</span></div>`;
+    if (profit >= baseTarget && profit < effectiveTarget) {{
+      targetNote += `<div class="row"><span class="label yellow">Profit target reached, consistency not met ($${{fmt(remaining,0)}} more)</span></div>`;
+    }}
+  }} else if (profit >= baseTarget) {{
+    targetNote = `<div class="row"><span class="label green">Target reached!</span></div>`;
+  }}
+
   document.getElementById('challenge-card').innerHTML = `
     <h2>FundedNext Challenge</h2>
     <div class="row"><span class="label">Starting Balance</span><span class="value">$50,000</span></div>
-    <div class="row"><span class="label">Profit Target</span><span class="value">$5,000</span></div>
+    <div class="row"><span class="label">Profit Target</span><span class="value">$${{fmt(effectiveTarget,0)}}${{consistencyAdj ? ' (consistency)' : ''}}</span></div>
     <div class="row"><span class="label">Current Profit</span>
       <span class="value ${{pnlC(profit)}}">${{pnlS(profit)}}$${{fmt(profit)}}</span></div>
     <div class="progress-bar"><div class="progress-fill" style="width:${{Math.max(0,pct)}}%;background:${{barColor}}"></div></div>
-    <div class="progress-label"><span>${{fmt(pct,1)}}% complete</span><span>$${{fmt(Math.max(0,5000-profit),0)}} remaining</span></div>
+    <div class="progress-label"><span>${{fmt(pct,1)}}% complete</span><span>$${{fmt(remaining,0)}} remaining</span></div>
+    ${{targetNote}}
     <div style="margin-top:10px">
       <div class="row"><span class="label">Max Trailing DD</span><span class="value">$2,500</span></div>
       <div class="row"><span class="label">Daily Loss Limit</span><span class="value">$2,500</span></div>

--- a/status.py
+++ b/status.py
@@ -226,11 +226,26 @@ def display(full=False):
     floor_color = R if to_floor < 500 else Y if to_floor < 1000 else G
     print(f"  To Floor: {floor_color}${to_floor:>12,.2f}{X}")
 
-    # Challenge progress
+    # Challenge progress (with consistency rule)
     profit = balance - 50000
-    target = 5000
-    pct = max(0, (profit / target) * 100) if target else 0
+    base_target = journal.get("base_target", 3000)
+    effective_target = journal.get("effective_target", base_target)
+    consistency_adjusted = journal.get("consistency_adjusted", False)
+    highest_day = journal.get("highest_day_profit", 0)
+
+    pct = max(0, (profit / effective_target) * 100) if effective_target else 0
+    remaining = max(0, effective_target - profit)
     print(f"  Progress: {_bar(min(100, pct))}")
+    if consistency_adjusted:
+        print(f"  {Y}Target: ${effective_target:,.0f} (raised from ${base_target:,.0f} — consistency rule){X}")
+        print(f"  {DIM}Highest day: ${highest_day:,.2f} / max 40% of total{X}")
+        print(f"  {DIM}Remaining:   ${remaining:,.2f}{X}")
+        if profit >= base_target and profit < effective_target:
+            print(f"  {Y}Profit target reached, but consistency not met yet (${remaining:,.0f} more needed){X}")
+    elif profit >= base_target:
+        print(f"  {G}Target reached!{X}")
+    else:
+        print(f"  {DIM}Target: ${base_target:,.0f} | Remaining: ${max(0, base_target - profit):,.2f}{X}")
 
     # Trading stats
     print(f"{'-' * W}")

--- a/trade_journal.py
+++ b/trade_journal.py
@@ -174,6 +174,54 @@ class TradeJournal:
             trades = [t for t in trades if t["date"] >= since]
         return trades
 
+    def daily_pnl_breakdown(self) -> dict[str, float]:
+        """Return P&L summed per day (date string -> total P&L)."""
+        by_day: dict[str, float] = defaultdict(float)
+        for t in self._closed_trades():
+            if t.get("pnl") is not None and t.get("date"):
+                by_day[t["date"]] += t["pnl"]
+        return dict(by_day)
+
+    def highest_day_profit(self) -> float:
+        """Return the highest single-day profit from trade history."""
+        by_day = self.daily_pnl_breakdown()
+        if not by_day:
+            return 0.0
+        return max(by_day.values())
+
+    def compute_effective_target(self) -> dict:
+        """Compute the effective profit target considering consistency rule.
+
+        FundedNext requires that no single day exceeds consistency_rule %
+        of total profit. If the highest day is large, the effective target
+        is raised so that day stays within the allowed percentage.
+
+        Returns dict with: base_target, effective_target, consistency_adjusted,
+        highest_day_profit, remaining.
+        """
+        settings = config.ACTIVE_CHALLENGE
+        base_target = settings.get("profit_target", 3_000)
+        consistency_pct = settings.get("consistency_rule", settings.get("consistency_rule_pct", 1.0))
+        highest_day = self.highest_day_profit()
+
+        if highest_day > 0 and consistency_pct < 1.0:
+            consistency_target = highest_day / consistency_pct
+            effective_target = max(base_target, consistency_target)
+        else:
+            effective_target = base_target
+
+        total_pnl = sum(t["pnl"] for t in self._closed_trades() if t.get("pnl") is not None)
+        remaining = max(0, effective_target - total_pnl)
+
+        return {
+            "base_target": base_target,
+            "effective_target": round(effective_target, 2),
+            "consistency_adjusted": effective_target > base_target,
+            "highest_day_profit": round(highest_day, 2),
+            "total_pnl": round(total_pnl, 2),
+            "remaining": round(remaining, 2),
+        }
+
     def _compute_summary(self) -> dict:
         """Compute overall performance summary."""
         closed = self._closed_trades()
@@ -186,6 +234,10 @@ class TradeJournal:
 
         avg_win = statistics.mean([t["pnl"] for t in wins]) if wins else 0
         avg_loss = statistics.mean([abs(t["pnl"]) for t in losses]) if losses else 0
+
+        # Challenge target with consistency rule
+        highest_day = self.highest_day_profit()
+        target_info = self.compute_effective_target()
 
         return {
             "total_trades": len(closed),
@@ -200,6 +252,10 @@ class TradeJournal:
             "best_trade": max(pnls) if pnls else 0,
             "worst_trade": min(pnls) if pnls else 0,
             "avg_r_multiple": statistics.mean([t.get("r_multiple", 0) for t in closed if t.get("r_multiple")]) if [t for t in closed if t.get("r_multiple")] else 0,
+            "highest_day_profit": highest_day,
+            "effective_target": target_info["effective_target"],
+            "base_target": target_info["base_target"],
+            "consistency_adjusted": target_info["consistency_adjusted"],
         }
 
     def analyze_by_symbol(self) -> dict:
@@ -400,6 +456,25 @@ class TradeJournal:
         print(f"  Profit Factor:{summary['profit_factor']:.2f}")
         print(f"  Expectancy:   ${summary['expectancy']:+,.2f}/trade")
         print(f"  Avg R:        {summary['avg_r_multiple']:+.2f}R")
+
+        # Challenge target progress
+        target_info = self.compute_effective_target()
+        y = "\033[33m"
+        g = "\033[32m"
+        if target_info["consistency_adjusted"]:
+            print(f"\n  {y}Challenge Target: ${target_info['effective_target']:,.0f} (raised from ${target_info['base_target']:,.0f} — consistency rule){r}")
+            print(f"  Highest day:   ${target_info['highest_day_profit']:,.2f} (max 40% of total profit)")
+            if pnl >= target_info["base_target"] and pnl < target_info["effective_target"]:
+                print(f"  {y}Profit target reached, but consistency not met — ${target_info['remaining']:,.0f} more needed{r}")
+            elif pnl >= target_info["effective_target"]:
+                print(f"  {g}Target reached (including consistency)!{r}")
+            else:
+                print(f"  Remaining:     ${target_info['remaining']:,.2f}")
+        else:
+            if pnl >= target_info["base_target"]:
+                print(f"\n  {g}Target reached!{r}")
+            else:
+                print(f"\n  Target: ${target_info['base_target']:,.0f} | Remaining: ${target_info['remaining']:,.2f}")
 
         # Per symbol
         by_sym = self.analyze_by_symbol()


### PR DESCRIPTION
FundedNext requires no single day to exceed 40% of total profit
(consistency rule). The bot previously showed a fixed $3,000 target,
but the effective target must be raised when the highest single-day
profit is large (e.g., $4,943 → effective target = $12,358).

Changes:
- config.py: Add consistency_rule alias to fundednext settings
- trade_journal.py: Add daily_pnl_breakdown(), highest_day_profit(),
  compute_effective_target() methods; update _compute_summary() and
  print_report() to show consistency-adjusted target
- status.py: Update terminal dashboard to show dynamic target with
  consistency warnings
- publish_dashboard.py: Update web dashboard JS to display dynamic
  target and consistency status

https://claude.ai/code/session_01U14JnFUZy5S1PTthLV5GpW