### PR TITLE
Add trading start time constraint to price processing

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -553,8 +553,9 @@ class TradovateBot:
 
         # Check time constraints
         current = now_et()
+        start = parse_time_et(config.TRADING_START_ET)
         cutoff = parse_time_et(config.TRADING_CUTOFF_ET)
-        if current >= cutoff:
+        if current < start or current >= cutoff:
             return
 
         # Feed price to strategy


### PR DESCRIPTION
## Summary
Added a trading start time constraint to the price processing logic to prevent strategy execution before market hours begin.

## Key Changes
- Parse `TRADING_START_ET` configuration value to establish the earliest time for trading activity
- Updated time constraint check to reject prices both before the trading start time and after the trading cutoff time
- Changed condition from `current >= cutoff` to `current < start or current >= cutoff` to enforce both boundaries

## Implementation Details
The price processing function now validates that the current time falls within the configured trading window `[TRADING_START_ET, TRADING_CUTOFF_ET)`. This ensures the strategy only processes prices during valid trading hours, preventing premature execution at market open and maintaining the existing cutoff behavior.

https://claude.ai/code/session_01EtggksdpbM5HQJLSXmDRV1