### PR TITLE
fix: root cause — stop restoring breakout_fired (blocks all ORB trading)

### DIFF
--- a/bot_state.py
+++ b/bot_state.py
@@ -136,13 +136,15 @@ def restore_strategies(state: dict, strategies: dict):
                 except (ValueError, TypeError):
                     pass
 
-            # Restore breakout_fired flags per window
+            # Restore range per window (but NOT breakout_fired —
+            # let warmup + live data decide when to fire breakouts)
             saved_windows = sym_state.get("windows", [])
             for i, w in enumerate(strategy.windows):
                 if i < len(saved_windows):
                     sw = saved_windows[i]
-                    if sw.get("breakout_fired"):
-                        w.breakout_fired = True
+                    # Do NOT restore breakout_fired — this was causing ORB
+                    # to never trade after restart because old state marked
+                    # breakouts as already consumed.
                     # Restore range if warmup didn't set it
                     if not w.range_set and sw.get("range_set"):
                         w.range_high = sw["range_high"]


### PR DESCRIPTION
ROOT CAUSE: bot_state.py restored breakout_fired=True + range_set=True from old state. Warmup skipped windows with range_set=True, so breakout_fired stayed True forever. ORB could never fire after any restart.