### PR TITLE
fix: cap position size at 2 contracts per trade

### DIFF
--- a/config.py
+++ b/config.py
@@ -336,6 +336,9 @@ FORCE_CLOSE_ET = ACTIVE_CHALLENGE["close_by_et"]
 # Lowered to 1.0% — tighter risk per trade, more trades allowed
 RISK_PER_TRADE_PCT = 0.010  # 1.0% of account per trade
 
+# Max contracts per single position (regardless of risk budget)
+MAX_CONTRACTS_PER_TRADE = 2
+
 # ─────────────────────────────────────────────
 # Logging
 # ─────────────────────────────────────────────

--- a/risk_manager.py
+++ b/risk_manager.py
@@ -289,6 +289,9 @@ class RiskManager:
 
         contracts = int(math.floor(trade_risk_budget / risk_per_contract))
 
+        # Cap at per-trade limit (user requested 2 contracts per position)
+        contracts = min(contracts, config.MAX_CONTRACTS_PER_TRADE)
+
         # Cap at available contract slots
         available = self.max_contracts - self.open_contracts
         contracts = min(contracts, available)


### PR DESCRIPTION
Bot was entering with 10 contracts instead of 2. Added MAX_CONTRACTS_PER_TRADE = 2.